### PR TITLE
FLAS-3: Improve Dark Mode Aesthetics

### DIFF
--- a/tests/test_apps/blueprintapp/apps/admin/static/css/test.css
+++ b/tests/test_apps/blueprintapp/apps/admin/static/css/test.css
@@ -1,1 +1,50 @@
 /* nested file */
+
+body {
+    background-color: #121212;
+    color: #ffffff;
+}
+
+form {
+    background-color: #1e1e1e;
+    padding: 20px;
+    border-radius: 8px;
+}
+
+input, textarea, select {
+    background-color: #2c2c2c;
+    color: #ffffff;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 10px;
+}
+
+.toggle-button {
+    position: relative;
+    width: 50px;
+    height: 25px;
+    background-color: #ccc;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.toggle-button:before {
+    content: '';
+    position: absolute;
+    width: 23px;
+    height: 23px;
+    background-color: #fff;
+    border-radius: 50%;
+    top: 1px;
+    left: 1px;
+    transition: transform 0.3s;
+}
+
+.toggle-button.active {
+    background-color: #4cd964;
+}
+
+.toggle-button.active:before {
+    transform: translateX(25px);
+}


### PR DESCRIPTION
### Description of the Change
This pull request addresses the issue of the dark mode feature being improperly implemented, as described in issue #FLAS-3. The changes include updating the CSS to ensure that the background of all pages and form elements are appropriately styled for dark mode.

### Changes Made
- Updated the `body` background color to `#121212` and text color to `#ffffff` to enhance readability in dark mode.
- Styled `form` elements with a background color of `#1e1e1e`, added padding, and rounded corners for a modern look.
- Modified `input`, `textarea`, and `select` elements to have a dark background, white text, and subtle border for better visibility.
- Implemented a new toggle button design resembling iPhone toggles, with smooth transitions and an active state color of `#4cd964`.

### Related Issues
- Fixes #FLAS-3: Dark mode is ugly

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.