### PR TITLE
FLAS-8: Implement Markdown Support in Post Body for September 6th Demo

### DIFF
--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -6,6 +6,7 @@ from flask import render_template
 from flask import request
 from flask import url_for
 from werkzeug.exceptions import abort
+import markdown
 
 from .auth import login_required
 from .db import get_db
@@ -22,6 +23,11 @@ def index():
         " FROM post p JOIN user u ON p.author_id = u.id"
         " ORDER BY created DESC"
     ).fetchall()
+    
+    # Convert markdown to HTML for each post body
+    for post in posts:
+        post['body'] = markdown.markdown(post['body'])
+    
     return render_template("blog/index.html", posts=posts)
 
 

--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -25,6 +25,7 @@ def index():
     ).fetchall()
     
     # Convert markdown to HTML for each post body
+    posts = [dict(post) for post in posts]  # Convert sqlite3.Row to dict
     for post in posts:
         post['body'] = markdown.markdown(post['body'])
     

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -19,7 +19,7 @@
           <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
         {% endif %}
       </header>
-      <p class="body">{{ post['body'] }}</p>
+      <p class="body">{{ post['body']|safe }}</p>
     </article>
     {% if not loop.last %}
       <hr>

--- a/flaskr/templates/blog/update.html
+++ b/flaskr/templates/blog/update.html
@@ -8,7 +8,7 @@
   <form method="post">
     <label for="title">Title</label>
     <input name="title" id="title" value="{{ request.form['title'] or post['title'] }}" required>
-    <label for="body">Body</label>
+    <label for="body">Body (Markdown supported)</label>
     <textarea name="body" id="body">{{ request.form['body'] or post['body'] }}</textarea>
     <input type="submit" value="Save">
   </form>


### PR DESCRIPTION
### Description of the Change
This pull request implements markdown support in the post body, addressing the issue titled "Markdown in post body - Neo." The changes allow users to write markdown in the edit page, and the main view of the posts will render the markdown as HTML.

### Code Changes
- **flaskr/blog.py**: Imported the `markdown` module and updated the `index` function to convert markdown content in each post's body to HTML before rendering.
- **flaskr/templates/blog/index.html**: Modified the template to render the post body as safe HTML using the `|safe` filter.
- **flaskr/templates/blog/update.html**: Updated the label for the body input to indicate markdown support.

### Related Issues
- Fixes #FLAS-8

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the markdown rendering.
- [ ] Update relevant documentation to reflect markdown support.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Ensure all steps in `CONTRIBUTING.rst` are complete.