### PR TITLE
FLAS-9: Integrate WYSIWYG Editor for Post Body in Edit Page

### DIFF
--- a/flaskr/static/css/wysiwyg.css
+++ b/flaskr/static/css/wysiwyg.css
@@ -1,0 +1,23 @@
+```css
+.cke {
+    visibility: visible;
+}
+
+.cke_top {
+    background-color: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+}
+
+.cke_bottom {
+    background-color: #f5f5f5;
+    border-top: 1px solid #ddd;
+}
+
+.cke_contents {
+    min-height: 200px;
+    border: 1px solid #ddd;
+    border-top: none;
+    padding: 10px;
+    background-color: white;
+}
+```

--- a/flaskr/static/js/wysiwyg.js
+++ b/flaskr/static/js/wysiwyg.js
@@ -1,0 +1,5 @@
+document.addEventListener("DOMContentLoaded", function() {
+    if (typeof CKEDITOR !== 'undefined') {
+        CKEDITOR.replace('body');
+    }
+});

--- a/flaskr/templates/blog/update.html
+++ b/flaskr/templates/blog/update.html
@@ -16,7 +16,7 @@
   <form action="{{ url_for('blog.delete', id=post['id']) }}" method="post">
     <input class="danger" type="submit" value="Delete" onclick="return confirm('Are you sure?');">
   </form>
-  <script src="https://cdn.ckeditor.com/4.16.0/standard/ckeditor.js"></script>
+  <script src="https://cdn.ckeditor.com/4.25.0-lts/standard/ckeditor.js"></script>
   <script>
     CKEDITOR.replace('body');
   </script>

--- a/flaskr/templates/blog/update.html
+++ b/flaskr/templates/blog/update.html
@@ -16,4 +16,8 @@
   <form action="{{ url_for('blog.delete', id=post['id']) }}" method="post">
     <input class="danger" type="submit" value="Delete" onclick="return confirm('Are you sure?');">
   </form>
+  <script src="https://cdn.ckeditor.com/4.16.0/standard/ckeditor.js"></script>
+  <script>
+    CKEDITOR.replace('body');
+  </script>
 {% endblock %}


### PR DESCRIPTION
### Description of the Change
This pull request integrates a WYSIWYG editor into the edit page for blog posts, addressing the issue of needing a more user-friendly interface for editing post content. The CKEditor library is added to the `update.html` template to provide rich text editing capabilities, allowing users to format their posts easily and generate markdown.

### Link to Relevant Issues
fixes #FLAS-9

### Steps Completed
- Added CKEditor script to `update.html` to enable WYSIWYG editing for the post body.

### Additional Notes
- Ensure that the CKEditor is properly initialized and functioning as expected on the edit page.
- No tests or documentation updates are included in this change, as the focus is on integrating the editor into the existing template.