### PR TITLE
FLAS-9: Integrate SimpleMDE WYSIWYG Editor into Post Edit Page

### DIFF
--- a/flaskr/templates/blog/update.html
+++ b/flaskr/templates/blog/update.html
@@ -16,4 +16,10 @@
   <form action="{{ url_for('blog.delete', id=post['id']) }}" method="post">
     <input class="danger" type="submit" value="Delete" onclick="return confirm('Are you sure?');">
   </form>
+
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+  <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+  <script>
+    var simplemde = new SimpleMDE({ element: document.getElementById("body") });
+  </script>
 {% endblock %}


### PR DESCRIPTION
### Description of the Change
This pull request integrates the SimpleMDE WYSIWYG editor into the post edit page of the application. The changes involve adding the necessary CSS and JavaScript links to the `update.html` template and initializing the SimpleMDE editor for the post body.

### How It Addresses the Issue
The issue requires the inclusion of a SimpleMDE WYSIWYG editor for the body of the posts on the edit page. This change directly addresses the issue by embedding the SimpleMDE editor, allowing users to have a more user-friendly interface for editing post content.

### Relevant Issues
fixes #FLAS-9

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.