### PR TITLE
FLAS-11: Implement Collapse/Expand Functionality for Post Bodies in List View

### DIFF
--- a/flaskr/static/style.css
+++ b/flaskr/static/style.css
@@ -132,3 +132,15 @@ input[type=submit] {
   align-self: start;
   min-width: 10em;
 }
+
+.toggle-body {
+  background-color: #377ba8;
+  color: white;
+  border: none;
+  padding: 0.5em;
+  cursor: pointer;
+}
+
+.toggle-body:hover {
+  background-color: #285a7a;
+}

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -18,11 +18,22 @@
         {% if g.user['id'] == post['author_id'] %}
           <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
         {% endif %}
+        <button class="toggle-body" onclick="toggleBody({{ post['id'] }})">Toggle</button>
       </header>
-      <p class="body">{{ post['body'] }}</p>
+      <p id="post-body-{{ post['id'] }}" class="body">{{ post['body'] }}</p>
     </article>
     {% if not loop.last %}
       <hr>
     {% endif %}
   {% endfor %}
+  <script>
+    function toggleBody(postId) {
+      const bodyElement = document.getElementById(`post-body-${postId}`);
+      if (bodyElement.style.display === "none") {
+        bodyElement.style.display = "block";
+      } else {
+        bodyElement.style.display = "none";
+      }
+    }
+  </script>
 {% endblock %}


### PR DESCRIPTION
### Description of the Change
This pull request introduces a feature that allows users to collapse and expand the body of each post individually in the list view. This is achieved by adding a "Toggle" button next to each post, which, when clicked, toggles the visibility of the post's body.

### Code Changes
- **CSS**: Added styles for the `.toggle-body` button to ensure it is visually distinct and interactive.
- **HTML**: Updated the `index.html` template to include a "Toggle" button for each post. The button is linked to a JavaScript function that manages the display state of the post body.
- **JavaScript**: Implemented the `toggleBody` function, which toggles the display property of the post body between `block` and `none` based on its current state.

### Related Issue
This pull request addresses the issue titled "Collapse/expand post in list - Francis".

### Checklist
- [ ] Add tests to verify the toggle functionality works as expected.
- [ ] Update documentation to reflect the new feature.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Ensure all steps in `CONTRIBUTING.rst` are complete.