### PR TITLE
FLAS-18: Implement Markdown Support in Post Body

### DIFF
--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -6,6 +6,7 @@ from flask import render_template
 from flask import request
 from flask import url_for
 from werkzeug.exceptions import abort
+import markdown
 
 from .auth import login_required
 from .db import get_db
@@ -22,6 +23,9 @@ def index():
         " FROM post p JOIN user u ON p.author_id = u.id"
         " ORDER BY created DESC"
     ).fetchall()
+    # Convert markdown to HTML for each post body
+    for post in posts:
+        post['body'] = markdown.markdown(post['body'])
     return render_template("blog/index.html", posts=posts)
 
 
@@ -53,6 +57,9 @@ def get_post(id, check_author=True):
 
     if check_author and post["author_id"] != g.user["id"]:
         abort(403)
+
+    # Convert markdown to HTML for the post body
+    post['body'] = markdown.markdown(post['body'])
 
     return post
 

--- a/flaskr/templates/blog/create.html
+++ b/flaskr/templates/blog/create.html
@@ -12,4 +12,8 @@
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
     <input type="submit" value="Save">
   </form>
+  <div class="preview">
+    <h2>Preview</h2>
+    <div class="body">{{ request.form['body']|safe }}</div>
+  </div>
 {% endblock %}

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -19,7 +19,7 @@
           <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
         {% endif %}
       </header>
-      <p class="body">{{ post['body'] }}</p>
+      <p class="body">{{ post['body']|safe }}</p>
     </article>
     {% if not loop.last %}
       <hr>

--- a/flaskr/templates/blog/update.html
+++ b/flaskr/templates/blog/update.html
@@ -16,4 +16,8 @@
   <form action="{{ url_for('blog.delete', id=post['id']) }}" method="post">
     <input class="danger" type="submit" value="Delete" onclick="return confirm('Are you sure?');">
   </form>
+  <div class="preview">
+    <h2>Preview</h2>
+    <div class="body">{{ post['body']|safe }}</div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
### Description of the Change
This pull request implements markdown support for the post body in the blog application. The markdown content is converted to HTML before rendering, allowing users to format their posts using markdown syntax.

### Code Changes
- Imported the `markdown` module in `flaskr/blog.py`.
- Updated the `index` and `get_post` functions to convert markdown content to HTML for each post body.
- Modified the `create.html`, `index.html`, and `update.html` templates to render the post body safely using the `|safe` filter, ensuring that the HTML generated from markdown is correctly displayed.
- Added a preview section in the `create.html` and `update.html` templates to show how the markdown content will be rendered.

### Related Issues
- fixes #FLAS-18

### Checklist
- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.