### PR TITLE
FLAS-19: Implement SimpleMDE for Markdown Editing in Post Creation

### DIFF
--- a/flaskr/static/style.css
+++ b/flaskr/static/style.css
@@ -224,3 +224,28 @@ body.dark-mode .content textarea {
   color: #e0e0e0;
   border: 1px solid #555;
 }
+
+/* SimpleMDE Custom Styles */
+.editor-toolbar {
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px 4px 0 0;
+}
+
+.CodeMirror {
+  border: 1px solid #ccc;
+  border-radius: 0 0 4px 4px;
+}
+
+.CodeMirror-scroll {
+  min-height: 12em;
+}
+
+body.dark-mode .editor-toolbar {
+  background: #333;
+  border: 1px solid #555;
+}
+
+body.dark-mode .CodeMirror {
+  border: 1px solid #555;
+}

--- a/flaskr/templates/blog/create.html
+++ b/flaskr/templates/blog/create.html
@@ -12,4 +12,9 @@
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
     <input type="submit" value="Save">
   </form>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+  <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+  <script>
+    var simplemde = new SimpleMDE({ element: document.getElementById("body") });
+  </script>
 {% endblock %}


### PR DESCRIPTION
### Description of the Change
This pull request implements the SimpleMDE editor to enhance the markdown editing experience when creating posts. The changes include adding the SimpleMDE library to the `create.html` template and applying custom styles in `style.css` to ensure a seamless integration with the existing design, including support for dark mode.

### How It Addresses the Issue
The issue titled "WYSIWYG" requested the implementation of a markdown editor for post creation. By integrating SimpleMDE, this PR provides a user-friendly interface for writing and editing markdown, addressing the core requirement of the issue.

### Relevant Issues
fixes #FLAS-19

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.