### PR TITLE
FLAS-30: Integrate SimpleMDE Editor into Blog Edit Pages

### DIFF
--- a/flaskr/static/style.css
+++ b/flaskr/static/style.css
@@ -228,3 +228,24 @@ body.dark-mode .content textarea {
   color: #e0e0e0;
   border: 1px solid #555;
 }
+
+/* SimpleMDE specific styles */
+.editor-toolbar {
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px 4px 0 0;
+}
+
+.CodeMirror {
+  border: 1px solid #ccc;
+  border-radius: 0 0 4px 4px;
+}
+
+body.dark-mode .editor-toolbar {
+  background: #333;
+  border: 1px solid #555;
+}
+
+body.dark-mode .CodeMirror {
+  border: 1px solid #555;
+}

--- a/flaskr/templates/blog/create.html
+++ b/flaskr/templates/blog/create.html
@@ -12,4 +12,9 @@
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
     <input type="submit" value="Save">
   </form>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+  <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+  <script>
+    var simplemde = new SimpleMDE({ element: document.getElementById("body") });
+  </script>
 {% endblock %}

--- a/flaskr/templates/blog/update.html
+++ b/flaskr/templates/blog/update.html
@@ -12,6 +12,11 @@
     <textarea name="body" id="body">{{ request.form['body'] or post['body'] }}</textarea>
     <input type="submit" value="Save">
   </form>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+  <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+  <script>
+    var simplemde = new SimpleMDE({ element: document.getElementById("body") });
+  </script>
   <hr>
   <form action="{{ url_for('blog.delete', id=post['id']) }}" method="post">
     <input class="danger" type="submit" value="Delete" onclick="return confirm('Are you sure?');">


### PR DESCRIPTION
### Description of the Change
This pull request integrates the SimpleMDE editor into the blog creation and update pages. The addition of this WYSIWYG editor enhances the user experience by providing a more intuitive interface for writing and editing blog posts.

### Changes Made
- Updated `create.html` and `update.html` templates to include SimpleMDE by adding the necessary CSS and JavaScript links.
- Initialized SimpleMDE on the `textarea` element for blog content, allowing users to write in markdown with a live preview.
- Added specific styles for SimpleMDE in `style.css` to ensure consistent appearance in both regular and dark modes.

### Related Issue
This PR addresses the issue titled "WYSIWYG" by adding the SimpleMDE editor to the blog edit pages. It is based on the existing markdown rendering implementation in the `feature/FLAS-29-markdown-in-post-body` branch.

### Checklist
- [ ] Tests have been added to demonstrate the correct behavior of the change.
- [ ] Documentation has been updated to reflect the changes.
- [ ] An entry has been added to `CHANGES.rst` summarizing the change and linking to the issue.

### Notes
Ensure that the PR is merged into the `feature/FLAS-29-markdown-in-post-body` branch as per the issue requirements.