### PR TITLE
FLAS-32: Implement Collapse/Expand Functionality for Blog Posts

### DIFF
--- a/flaskr/static/collapse.js
+++ b/flaskr/static/collapse.js
@@ -1,0 +1,24 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const toggleAllButton = document.getElementById("toggle-all");
+    const postHeaders = document.querySelectorAll(".post-header");
+    const posts = document.querySelectorAll(".post");
+
+    toggleAllButton.addEventListener("click", function() {
+        posts.forEach(post => {
+            post.classList.toggle("collapsed");
+        });
+    });
+
+    postHeaders.forEach(header => {
+        header.addEventListener("click", function(event) {
+            const postId = event.currentTarget.getAttribute("onclick").match(/\d+/)[0];
+            togglePostBody(postId);
+        });
+    });
+});
+
+function togglePostBody(postId) {
+    const postBody = document.getElementById(`post-body-${postId}`);
+    const post = postBody.closest(".post");
+    post.classList.toggle("collapsed");
+}

--- a/flaskr/static/style.css
+++ b/flaskr/static/style.css
@@ -88,6 +88,7 @@ nav ul li a, nav ul li span, header .action {
   display: flex;
   align-items: flex-end;
   font-size: 0.85em;
+  cursor: pointer;
 }
 
 .post > header > div:first-of-type {
@@ -106,6 +107,7 @@ nav ul li a, nav ul li span, header .action {
 
 .post .body {
   white-space: pre-line;
+  display: block;
 }
 
 .content:last-child {
@@ -227,4 +229,8 @@ body.dark-mode .content textarea {
   background: #333;
   color: #e0e0e0;
   border: 1px solid #555;
+}
+
+.post.collapsed .body {
+  display: none;
 }

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -10,9 +10,9 @@
 {% block content %}
   {% for post in posts %}
     <article class="post">
-      <header class="post-header" onclick="togglePostBody({{ post['id'] }})">
+      <header class="post-header">
         <div>
-          <h1>{{ post['title'] }}</h1>
+          <h1 onclick="togglePostBody({{ post['id'] }})">{{ post['title'] }}</h1>
           <div class="about">by {{ post['username'] }} on {{ post['created'].strftime('%Y-%m-%d') }}</div>
         </div>
         {% if g.user['id'] == post['author_id'] %}

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block header %}
-  <h1>{% block title %}Posts{% endblock %}</h1>
+  <h1 id="toggle-all">Posts</h1>
   {% if g.user %}
     <a class="action" href="{{ url_for('blog.create') }}">New</a>
   {% endif %}
@@ -10,7 +10,7 @@
 {% block content %}
   {% for post in posts %}
     <article class="post">
-      <header>
+      <header class="post-header" onclick="togglePostBody({{ post['id'] }})">
         <div>
           <h1>{{ post['title'] }}</h1>
           <div class="about">by {{ post['username'] }} on {{ post['created'].strftime('%Y-%m-%d') }}</div>
@@ -19,10 +19,11 @@
           <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
         {% endif %}
       </header>
-      <p class="body">{{ post['body'] }}</p>
+      <p class="body" id="post-body-{{ post['id'] }}">{{ post['body'] }}</p>
     </article>
     {% if not loop.last %}
       <hr>
     {% endif %}
   {% endfor %}
+  <script src="{{ url_for('static', filename='collapse.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
### Description of the Change
This pull request addresses the issue of making blog posts collapsible in the main blog view. The changes allow users to toggle the visibility of individual post bodies by clicking on the post header, as well as toggle the visibility of all posts simultaneously by clicking on the "Posts" header at the top of the page.

### Code Changes
- **CSS Modifications**: Added a `cursor: pointer;` style to indicate clickable elements and a `.post.collapsed .body` class to hide the post body when collapsed.
- **HTML Template Updates**: 
  - Added an `id="toggle-all"` to the "Posts" header for toggling all posts.
  - Updated post headers to include an `onclick` event that triggers the `togglePostBody` function.
  - Added `id` attributes to post bodies for individual toggling.
  - Included a script reference to `collapse.js` for handling the toggle functionality.

### Related Issues
- Fixes #32

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.