### PR TITLE
FLAS-33: Implement Pagination for Blog Posts

### DIFF
--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -18,16 +18,22 @@ bp = Blueprint("blog", __name__)
 def index():
     """Show all the posts, most recent first."""
     db = get_db()
+    page = request.args.get('page', 1, type=int)
+    posts_per_page = 10
+    offset = (page - 1) * posts_per_page
+
     posts = db.execute(
         "SELECT p.id, title, body, created, author_id, username"
         " FROM post p JOIN user u ON p.author_id = u.id"
         " ORDER BY created DESC"
+        " LIMIT ? OFFSET ?",
+        (posts_per_page, offset)
     ).fetchall()
     # Convert markdown to HTML for each post body
     posts = [
         {**post, 'body': markdown.markdown(post['body'])} for post in posts
     ]
-    return render_template("blog/index.html", posts=posts)
+    return render_template("blog/index.html", posts=posts, page=page)
 
 
 def get_post(id, check_author=True):

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -25,5 +25,16 @@
       <hr>
     {% endif %}
   {% endfor %}
+
+  <div class="pagination">
+    {% if page > 1 %}
+      <a href="{{ url_for('blog.index', page=page-1) }}">Previous</a>
+    {% endif %}
+    <span>Page {{ page }}</span>
+    {% if posts|length == 10 %}
+      <a href="{{ url_for('blog.index', page=page+1) }}">Next</a>
+    {% endif %}
+  </div>
+
   <script src="{{ url_for('static', filename='collapse.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
### Description of the Change
This pull request implements a pagination feature for the blog posts, addressing the issue titled "Pagination with 10 post/page." The changes ensure that only 10 posts are displayed per page, enhancing the user experience by preventing long scrolling on the blog index page.

### Code Changes
- **`flaskr/blog.py`**: Modified the `index` function to include pagination logic. The function now calculates the offset based on the current page number and limits the number of posts fetched from the database to 10 per page.
- **`flaskr/templates/blog/index.html`**: Updated the template to include pagination controls. Added "Previous" and "Next" links to navigate between pages and display the current page number.

### Related Issue
Fixes #FLAS-33

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the pagination feature.
- [ ] Update relevant documentation in the `docs` folder and in the code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.