### PR TITLE
FLAS-34: Add Spanish Translation Support for Main Blog Page

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import Flask, request, g
-
+from flask_babel import Babel
 
 def create_app(test_config=None):
     """Create and configure an instance of the Flask application."""
@@ -12,6 +12,9 @@ def create_app(test_config=None):
         SECRET_KEY="dev",
         # store the database in the instance folder
         DATABASE=os.path.join(app.instance_path, "flaskr.sqlite"),
+        # configuration for Babel
+        BABEL_DEFAULT_LOCALE='en',
+        BABEL_SUPPORTED_LOCALES=['en', 'es'],
     )
 
     if test_config is None:
@@ -26,6 +29,12 @@ def create_app(test_config=None):
         os.makedirs(app.instance_path)
     except OSError:
         pass
+
+    babel = Babel(app)
+
+    @babel.localeselector
+    def get_locale():
+        return request.args.get('locale', 'en')
 
     @app.route("/hello")
     def hello():

--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -7,12 +7,12 @@ from flask import request
 from flask import url_for
 from werkzeug.exceptions import abort
 import markdown
+from flask_babel import _
 
 from .auth import login_required
 from .db import get_db
 
 bp = Blueprint("blog", __name__)
-
 
 @bp.route("/")
 def index():
@@ -72,7 +72,7 @@ def create():
         error = None
 
         if not title:
-            error = "Title is required."
+            error = _("Title is required.")
 
         if error is not None:
             flash(error)
@@ -100,7 +100,7 @@ def update(id):
         error = None
 
         if not title:
-            error = "Title is required."
+            error = _("Title is required.")
 
         if error is not None:
             flash(error)

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 
 {% block header %}
-  <h1 id="toggle-all">Posts</h1>
+  <h1 id="toggle-all">{{ _('Posts') }}</h1>
   {% if g.user %}
-    <a class="action" href="{{ url_for('blog.create') }}">New</a>
+    <a class="action" href="{{ url_for('blog.create') }}">{{ _('New') }}</a>
   {% endif %}
 {% endblock %}
 
@@ -13,10 +13,10 @@
       <header class="post-header">
         <div>
           <h1 onclick="togglePostBody({{ post['id'] }})">{{ post['title'] }}</h1>
-          <div class="about">by {{ post['username'] }} on {{ post['created'].strftime('%Y-%m-%d') }}</div>
+          <div class="about">{{ _('by') }} {{ post['username'] }} {{ _('on') }} {{ post['created'].strftime('%Y-%m-%d') }}</div>
         </div>
         {% if g.user['id'] == post['author_id'] %}
-          <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
+          <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">{{ _('Edit') }}</a>
         {% endif %}
       </header>
       <p class="body" id="post-body-{{ post['id'] }}">{{ post['body'] |safe }}</p>

--- a/flaskr/translations/es/LC_MESSAGES/messages.po
+++ b/flaskr/translations/es/LC_MESSAGES/messages.po
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: es\n"
+
+msgid "Posts"
+msgstr "Publicaciones"
+
+msgid "New"
+msgstr "Nuevo"
+
+msgid "by"
+msgstr "por"
+
+msgid "on"
+msgstr "en"
+
+msgid "Edit"
+msgstr "Editar"
+
+msgid "Title is required."
+msgstr "Se requiere título."


### PR DESCRIPTION
### Description of the Change
This pull request introduces basic support for Spanish translations on the main blog page. It allows users to change the language based on a URL parameter `locale`. The implementation utilizes Flask-Babel to manage translations.

### Code Changes
- **Initialization**: Added Flask-Babel to the Flask app in `flaskr/__init__.py` with default locale set to English and supported locales including Spanish.
- **Locale Selector**: Implemented a locale selector function to determine the language based on the `locale` URL parameter.
- **Translation Integration**: Updated strings in `flaskr/blog.py` and `flaskr/templates/blog/index.html` to use the `_()` function for translation, enabling dynamic language switching.

### Related Issue
fixes #FLAS-34

### Contribution Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.