### PR TITLE
FLAS-34: Add Spanish Translation Support for Blog Page

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 from flask import Flask, request, g
+from .translations import get_translation
 
 
 def create_app(test_config=None):
@@ -38,6 +39,11 @@ def create_app(test_config=None):
             g.theme = theme
         else:
             g.theme = 'dark' if request.user_agent.platform in ['android', 'iphone'] and request.user_agent.browser in ['chrome', 'safari'] and request.user_agent.string.find('DarkMode') != -1 else 'light'
+
+    @app.before_request
+    def load_locale():
+        locale = request.args.get('locale', 'en_GB')
+        g.locale = locale
 
     # register the database commands
     from . import db

--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -10,6 +10,7 @@ import markdown
 
 from .auth import login_required
 from .db import get_db
+from .translations import get_translation
 
 bp = Blueprint("blog", __name__)
 
@@ -27,7 +28,9 @@ def index():
     posts = [
         {**post, 'body': markdown.markdown(post['body'])} for post in posts
     ]
-    return render_template("blog/index.html", posts=posts)
+    # Get translations for the current locale
+    translations = get_translation(g.locale)
+    return render_template("blog/index.html", posts=posts, translations=translations)
 
 
 def get_post(id, check_author=True):

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 
 {% block header %}
-  <h1 id="toggle-all">Posts</h1>
+  <h1 id="toggle-all">{{ translations['Posts'] }}</h1>
   {% if g.user %}
-    <a class="action" href="{{ url_for('blog.create') }}">New</a>
+    <a class="action" href="{{ url_for('blog.create') }}">{{ translations['New'] }}</a>
   {% endif %}
 {% endblock %}
 
@@ -16,7 +16,7 @@
           <div class="about">by {{ post['username'] }} on {{ post['created'].strftime('%Y-%m-%d') }}</div>
         </div>
         {% if g.user['id'] == post['author_id'] %}
-          <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
+          <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">{{ translations['Edit'] }}</a>
         {% endif %}
       </header>
       <p class="body" id="post-body-{{ post['id'] }}">{{ post['body'] |safe }}</p>

--- a/flaskr/translations.py
+++ b/flaskr/translations.py
@@ -1,0 +1,19 @@
+translations = {
+    'en_GB': {
+        'Posts': 'Posts',
+        'Log In': 'Log In',
+        'Log Out': 'Log Out',
+        'New': 'New',
+        'Edit': 'Edit',
+    },
+    'es_ES': {
+        'Posts': 'Entradas',
+        'Log In': 'Iniciar sesion',
+        'Log Out': 'Salir',
+        'New': 'Nuevo',
+        'Edit': 'Editar',
+    }
+}
+
+def get_translation(locale):
+    return translations.get(locale, translations['en_GB'])


### PR DESCRIPTION
### Description of the Change
This pull request implements basic support for translations on the main blog page, addressing the issue of allowing users to change the language based on a URL parameter `locale`. The changes include loading the locale from the request parameters and using translation values in the blog page template.

### Code Changes
- **`flaskr/__init__.py`**: Added a `before_request` function to load the locale from the URL parameters and store it in the global object `g`.
- **`flaskr/blog.py`**: Integrated the `get_translation` function to fetch translations based on the current locale and pass them to the template.
- **`flaskr/templates/blog/index.html`**: Updated the template to use translation keys for text elements like "Posts", "New", and "Edit".

### Related Issues
- Fixes #FLAS-34

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the `docs` folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.