### PR TITLE
FLAS-40: Implement Basic Translation Support for Main Blog Page

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -39,6 +39,13 @@ def create_app(test_config=None):
         else:
             g.theme = 'dark' if request.user_agent.platform in ['android', 'iphone'] and request.user_agent.browser in ['chrome', 'safari'] and request.user_agent.string.find('DarkMode') != -1 else 'light'
 
+    @app.before_request
+    def load_locale():
+        locale = request.args.get('locale')
+        if locale not in ['en_GB', 'es_ES']:
+            locale = 'en_GB'
+        g.locale = locale
+
     # register the database commands
     from . import db
 

--- a/flaskr/templates/base.html
+++ b/flaskr/templates/base.html
@@ -12,10 +12,10 @@
     </li>
     {% if g.user %}
       <li><span>{{ g.user['username'] }}</span>
-      <li><a href="{{ url_for('auth.logout') }}">Log Out</a>
+      <li><a href="{{ url_for('auth.logout') }}">{{ translate('Log Out', g.locale) }}</a>
     {% else %}
-      <li><a href="{{ url_for('auth.register') }}">Register</a>
-      <li><a href="{{ url_for('auth.login') }}">Log In</a>
+      <li><a href="{{ url_for('auth.register') }}">{{ translate('Register', g.locale) }}</a>
+      <li><a href="{{ url_for('auth.login') }}">{{ translate('Log In', g.locale) }}</a>
     {% endif %}
   </ul>
 </nav>

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 
 {% block header %}
-  <h1>{% block title %}Posts{% endblock %}</h1>
+  <h1>{% block title %}{{ translate('Posts', g.locale) }}{% endblock %}</h1>
   {% if g.user %}
-    <a class="action" href="{{ url_for('blog.create') }}">New</a>
+    <a class="action" href="{{ url_for('blog.create') }}">{{ translate('New', g.locale) }}</a>
   {% endif %}
 {% endblock %}
 
@@ -16,7 +16,7 @@
           <div class="about">by {{ post['username'] }} on {{ post['created'].strftime('%Y-%m-%d') }}</div>
         </div>
         {% if g.user['id'] == post['author_id'] %}
-          <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
+          <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">{{ translate('Edit', g.locale) }}</a>
         {% endif %}
       </header>
       <p class="body">{{ post['body'] }}</p>

--- a/flaskr/translations.py
+++ b/flaskr/translations.py
@@ -1,0 +1,21 @@
+translations = {
+    'en_GB': {
+        'Posts': 'Posts',
+        'Log In': 'Log In',
+        'Log Out': 'Log Out',
+        'Register': 'Register',
+        'New': 'New',
+        'Edit': 'Edit'
+    },
+    'es_ES': {
+        'Posts': 'Entradas',
+        'Log In': 'Iniciar sesion',
+        'Log Out': 'Salir',
+        'Register': 'Registrarse',
+        'New': 'Nuevo',
+        'Edit': 'Editar'
+    }
+}
+
+def translate(text, locale):
+    return translations.get(locale, {}).get(text, text)


### PR DESCRIPTION
### Description of the Change
This pull request implements basic support for translations on the main blog page. It allows users to change the language based on a URL parameter `locale`. The supported locales are `en_GB` and `es_ES`. The translation values are referenced from the confluence page linked in the issue.

### How It Addresses the Issue
The changes address the issue by introducing a `load_locale` function in the `flaskr/__init__.py` file, which sets the locale based on the URL parameter. If the locale is not supported, it defaults to `en_GB`. Additionally, the templates have been updated to use a `translate` function to display text in the selected language.

### Relevant Issues
fixes #FLAS-40

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.