### PR TITLE
FLAS-59: Implement Markdown Support in Post Body

### DIFF
--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -24,8 +24,9 @@ def index():
         " ORDER BY created DESC"
     ).fetchall()
     # Convert markdown to HTML for each post body
-    for post in posts:
-        post['body'] = markdown.markdown(post['body'])
+    posts = [
+        {**post, 'body': markdown.markdown(post['body'])} for post in posts
+    ]
     return render_template("blog/index.html", posts=posts)
 
 

--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -6,6 +6,7 @@ from flask import render_template
 from flask import request
 from flask import url_for
 from werkzeug.exceptions import abort
+import markdown
 
 from .auth import login_required
 from .db import get_db
@@ -22,6 +23,9 @@ def index():
         " FROM post p JOIN user u ON p.author_id = u.id"
         " ORDER BY created DESC"
     ).fetchall()
+    # Convert markdown to HTML for each post body
+    for post in posts:
+        post['body'] = markdown.markdown(post['body'])
     return render_template("blog/index.html", posts=posts)
 
 

--- a/flaskr/templates/blog/create.html
+++ b/flaskr/templates/blog/create.html
@@ -10,6 +10,7 @@
     <input name="title" id="title" value="{{ request.form['title'] }}" required>
     <label for="body">Body</label>
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
+    <p><em>Markdown is supported in the body.</em></p>
     <input type="submit" value="Save">
   </form>
 {% endblock %}

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -19,7 +19,7 @@
           <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
         {% endif %}
       </header>
-      <p class="body">{{ post['body'] }}</p>
+      <p class="body">{{ post['body']|safe }}</p>
     </article>
     {% if not loop.last %}
       <hr>

--- a/flaskr/templates/blog/update.html
+++ b/flaskr/templates/blog/update.html
@@ -10,6 +10,7 @@
     <input name="title" id="title" value="{{ request.form['title'] or post['title'] }}" required>
     <label for="body">Body</label>
     <textarea name="body" id="body">{{ request.form['body'] or post['body'] }}</textarea>
+    <p><em>Markdown is supported in the body.</em></p>
     <input type="submit" value="Save">
   </form>
   <hr>


### PR DESCRIPTION
### Description of the Change
This pull request implements markdown support in the post body, addressing the issue described in the September 16th demo specification. The changes ensure that markdown content in the post body is correctly converted to HTML when displayed.

### Link to Relevant Issues
fixes #FLAS-59

### Key Changes
- Imported the `markdown` module in `flaskr/blog.py` to convert markdown text to HTML.
- Updated the `index` function in `flaskr/blog.py` to process each post's body with `markdown.markdown()`.
- Modified `create.html` and `update.html` templates to inform users that markdown is supported in the post body.
- Updated `index.html` to render the post body safely using the `|safe` filter, allowing HTML content generated from markdown to be displayed correctly.

### Contribution Checklist
- [ ] Add tests to demonstrate the correct behavior of the markdown conversion.
- [ ] Update relevant documentation to reflect markdown support.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Ensure `.. versionchanged::` entries are added in relevant code docs if necessary.