### PR TITLE
FLAS-67: Implement Markdown Support in Blog Post Body

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 from flask import Flask, request, g
+import markdown
 
 
 def create_app(test_config=None):

--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -6,6 +6,7 @@ from flask import render_template
 from flask import request
 from flask import url_for
 from werkzeug.exceptions import abort
+import markdown
 
 from .auth import login_required
 from .db import get_db
@@ -22,6 +23,9 @@ def index():
         " FROM post p JOIN user u ON p.author_id = u.id"
         " ORDER BY created DESC"
     ).fetchall()
+    # Convert markdown to HTML for each post body
+    for post in posts:
+        post['body'] = markdown.markdown(post['body'])
     return render_template("blog/index.html", posts=posts)
 
 

--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -23,6 +23,8 @@ def index():
         " FROM post p JOIN user u ON p.author_id = u.id"
         " ORDER BY created DESC"
     ).fetchall()
+    # Convert the immutable cursor to a list of dictionaries
+    posts = [dict(post) for post in posts]
     # Convert markdown to HTML for each post body
     for post in posts:
         post['body'] = markdown.markdown(post['body'])

--- a/flaskr/templates/blog/create.html
+++ b/flaskr/templates/blog/create.html
@@ -8,7 +8,7 @@
   <form method="post">
     <label for="title">Title</label>
     <input name="title" id="title" value="{{ request.form['title'] }}" required>
-    <label for="body">Body</label>
+    <label for="body">Body (Markdown supported)</label>
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
     <input type="submit" value="Save">
   </form>

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -19,7 +19,7 @@
           <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
         {% endif %}
       </header>
-      <p class="body">{{ post['body'] }}</p>
+      <p class="body">{{ post['body']|safe }}</p>
     </article>
     {% if not loop.last %}
       <hr>

--- a/flaskr/templates/blog/update.html
+++ b/flaskr/templates/blog/update.html
@@ -8,7 +8,7 @@
   <form method="post">
     <label for="title">Title</label>
     <input name="title" id="title" value="{{ request.form['title'] or post['title'] }}" required>
-    <label for="body">Body</label>
+    <label for="body">Body (Markdown supported)</label>
     <textarea name="body" id="body">{{ request.form['body'] or post['body'] }}</textarea>
     <input type="submit" value="Save">
   </form>


### PR DESCRIPTION
### Description of the Change
This pull request implements markdown support for the blog post body in the Flask application. The changes allow users to enter markdown in the create and update interfaces, which is then rendered as HTML in the main blog interface.

### Changes Made
- Imported the `markdown` module in `flaskr/__init__.py` and `flaskr/blog.py`.
- Updated the `index` function in `flaskr/blog.py` to convert markdown to HTML for each post body before rendering.
- Modified the `create.html` and `update.html` templates to indicate that markdown is supported in the post body.
- Updated the `index.html` template to render the post body safely as HTML using the `|safe` filter.

### Related Issues
fixes #FLAS-67

### Checklist
- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant documentation in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.