### PR TITLE
FLAS-70: Implement Collapse/Expand Functionality for Posts in List View

### DIFF
--- a/flaskr/static/style.css
+++ b/flaskr/static/style.css
@@ -226,3 +226,17 @@ body.dark-mode .content textarea {
   color: #e0e0e0;
   border: 1px solid #555;
 }
+
+.toggle-content {
+  background: none;
+  border: none;
+  color: #377ba8;
+  cursor: pointer;
+  font-size: 0.85em;
+  margin-left: 1em;
+  transition: color 0.3s;
+}
+
+.toggle-content:hover {
+  color: #2c5f8a;
+}

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -18,11 +18,24 @@
         {% if g.user['id'] == post['author_id'] %}
           <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
         {% endif %}
+        <button class="toggle-content" onclick="toggleContent(this)">Expand</button>
       </header>
-      <p class="body">{{ post['body'] }}</p>
+      <p class="body" style="display: none;">{{ post['body'] }}</p>
     </article>
     {% if not loop.last %}
       <hr>
     {% endif %}
   {% endfor %}
+  <script>
+    function toggleContent(button) {
+      const body = button.parentElement.nextElementSibling;
+      if (body.style.display === "none") {
+        body.style.display = "block";
+        button.textContent = "Collapse";
+      } else {
+        body.style.display = "none";
+        button.textContent = "Expand";
+      }
+    }
+  </script>
 {% endblock %}


### PR DESCRIPTION
### Description of the Change
This pull request implements the functionality to collapse or expand posts in the list view, addressing the issue titled "Collapse/expand post in list." The changes involve adding a toggle button to each post, allowing users to expand or collapse the post content.

### Code Changes
- **CSS Updates**: Added styles for the `.toggle-content` button to ensure it is visually distinct and interactive.
- **HTML and JavaScript**: Updated the `index.html` template to include a button for toggling the visibility of the post content. A JavaScript function `toggleContent` is introduced to handle the expand/collapse logic by changing the display style of the post body and updating the button text accordingly.

### Related Issues
- fixes #FLAS-70

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.