### PR TITLE
FLAS-71: Implement Pagination for Blog Posts

### DIFF
--- a/flaskr/blog.py
+++ b/flaskr/blog.py
@@ -13,22 +13,31 @@ from .db import get_db
 
 bp = Blueprint("blog", __name__)
 
+POSTS_PER_PAGE = 10
 
 @bp.route("/")
 def index():
     """Show all the posts, most recent first."""
+    page = request.args.get('page', 1, type=int)
     db = get_db()
     posts = db.execute(
         "SELECT p.id, title, body, created, author_id, username"
         " FROM post p JOIN user u ON p.author_id = u.id"
         " ORDER BY created DESC"
+        " LIMIT ? OFFSET ?",
+        (POSTS_PER_PAGE, (page - 1) * POSTS_PER_PAGE)
     ).fetchall()
     # Convert the immutable cursor to a list of dictionaries
     posts = [dict(post) for post in posts]
     # Convert markdown to HTML for each post body
     for post in posts:
         post['body'] = markdown.markdown(post['body'])
-    return render_template("blog/index.html", posts=posts)
+
+    # Get the total number of posts to calculate pagination
+    total_posts = db.execute("SELECT COUNT(id) FROM post").fetchone()[0]
+    total_pages = (total_posts + POSTS_PER_PAGE - 1) // POSTS_PER_PAGE
+
+    return render_template("blog/index.html", posts=posts, page=page, total_pages=total_pages)
 
 
 def get_post(id, check_author=True):

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -26,6 +26,19 @@
       <hr>
     {% endif %}
   {% endfor %}
+  
+  <div class="pagination">
+    {% if page > 1 %}
+      <a href="{{ url_for('blog.index', page=1) }}">First</a>
+      <a href="{{ url_for('blog.index', page=page-1) }}">Previous</a>
+    {% endif %}
+    <span>Page {{ page }} of {{ total_pages }}</span>
+    {% if page < total_pages %}
+      <a href="{{ url_for('blog.index', page=page+1) }}">Next</a>
+      <a href="{{ url_for('blog.index', page=total_pages) }}">Last</a>
+    {% endif %}
+  </div>
+
   <script>
     function toggleContent(button) {
       const body = button.parentElement.nextElementSibling;


### PR DESCRIPTION
### Description of the Change
This pull request implements a pagination feature for the blog section of the application, addressing the issue titled "Pagination with 10 post/page." The changes ensure that only 10 posts are displayed per page, with navigation controls to access the first, previous, next, and last pages.

### Code Changes
- **`flaskr/blog.py`**: 
  - Introduced a constant `POSTS_PER_PAGE` set to 10.
  - Modified the `index` function to include pagination logic, fetching posts based on the current page and calculating the total number of pages.
  - Updated the SQL query to limit the number of posts fetched and calculate the offset based on the current page.
  - Added logic to calculate `total_pages` for pagination.

- **`flaskr/templates/blog/index.html`**:
  - Added pagination controls to navigate between pages, displaying links for "First," "Previous," "Next," and "Last" pages.
  - Displayed the current page number and total pages.

### Related Issue
fixes #FLAS-71

### Checklist
- [ ] Add tests to demonstrate the correct behavior of the pagination feature.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.