### PR TITLE
FLAS-73: Add Basic Translation Support Using Locale Parameter

### DIFF
--- a/flaskr/templates/auth/login.html
+++ b/flaskr/templates/auth/login.html
@@ -1,7 +1,8 @@
 {% extends 'base.html' %}
 
 {% block header %}
-  <h1>{% block title %}Log In{% endblock %}</h1>
+  {% set locale = request.args.get('locale', 'en_GB') %}
+  <h1>{% block title %}{{ 'Log In' if locale == 'en_GB' else 'Iniciar sesion' }}{% endblock %}</h1>
 {% endblock %}
 
 {% block content %}
@@ -10,6 +11,6 @@
     <input name="username" id="username" required>
     <label for="password">Password</label>
     <input type="password" name="password" id="password" required>
-    <input type="submit" value="Log In">
+    <input type="submit" value="{{ 'Log In' if locale == 'en_GB' else 'Iniciar sesion' }}">
   </form>
 {% endblock %}

--- a/flaskr/templates/auth/register.html
+++ b/flaskr/templates/auth/register.html
@@ -1,7 +1,8 @@
 {% extends 'base.html' %}
 
 {% block header %}
-  <h1>{% block title %}Register{% endblock %}</h1>
+  {% set locale = request.args.get('locale', 'en_GB') %}
+  <h1>{% block title %}{{ 'Register' if locale == 'en_GB' else 'Registrarse' }}{% endblock %}</h1>
 {% endblock %}
 
 {% block content %}
@@ -10,6 +11,6 @@
     <input name="username" id="username" required>
     <label for="password">Password</label>
     <input type="password" name="password" id="password" required>
-    <input type="submit" value="Register">
+    <input type="submit" value="{{ 'Register' if locale == 'en_GB' else 'Registrarse' }}">
   </form>
 {% endblock %}

--- a/flaskr/templates/base.html
+++ b/flaskr/templates/base.html
@@ -10,9 +10,10 @@
         <!-- <i id="theme-icon" class="fas fa-moon"></i> -->
       </div>
     </li>
+    {% set locale = request.args.get('locale', 'en_GB') %}
     {% if g.user %}
       <li><span>{{ g.user['username'] }}</span>
-      <li><a href="{{ url_for('auth.logout') }}">Log Out</a>
+      <li><a href="{{ url_for('auth.logout') }}">{{ 'Log Out' if locale == 'en_GB' else 'Salir' }}</a>
     {% else %}
       <li><a href="{{ url_for('auth.register') }}">Register</a>
       <li><a href="{{ url_for('auth.login') }}">Log In</a>

--- a/flaskr/templates/base.html
+++ b/flaskr/templates/base.html
@@ -15,8 +15,8 @@
       <li><span>{{ g.user['username'] }}</span>
       <li><a href="{{ url_for('auth.logout') }}">{{ 'Log Out' if locale == 'en_GB' else 'Salir' }}</a>
     {% else %}
-      <li><a href="{{ url_for('auth.register') }}">Register</a>
-      <li><a href="{{ url_for('auth.login') }}">Log In</a>
+      <li><a href="{{ url_for('auth.register') }}">{{ 'Register' if locale == 'en_GB' else 'Registrarse' }}</a>
+      <li><a href="{{ url_for('auth.login') }}">{{ 'Log In' if locale == 'en_GB' else 'Iniciar sesion' }}</a>
     {% endif %}
   </ul>
 </nav>

--- a/flaskr/templates/blog/index.html
+++ b/flaskr/templates/blog/index.html
@@ -1,9 +1,10 @@
 {% extends 'base.html' %}
 
 {% block header %}
-  <h1>{% block title %}Today in history{% endblock %}</h1>
+  {% set locale = request.args.get('locale', 'en_GB') %}
+  <h1>{% block title %}{{ 'Today in history' if locale == 'en_GB' else 'Efemérides' }}{% endblock %}</h1>
   {% if g.user %}
-    <a class="action" href="{{ url_for('blog.create') }}">New</a>
+    <a class="action" href="{{ url_for('blog.create') }}">{{ 'New' if locale == 'en_GB' else 'Nuevo' }}</a>
   {% endif %}
 {% endblock %}
 
@@ -16,9 +17,9 @@
           <div class="about">by {{ post['username'] }} on {{ post['created'].strftime('%Y-%m-%d') }}</div>
         </div>
         {% if g.user['id'] == post['author_id'] %}
-          <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
+          <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">{{ 'Edit' if locale == 'en_GB' else 'Editar' }}</a>
         {% endif %}
-        <button class="toggle-content" onclick="toggleContent(this)">Expand</button>
+        <button class="toggle-content" onclick="toggleContent(this)">{{ 'Expand' if locale == 'en_GB' else 'Desplegar' }}</button>
       </header>
       <div style="display:none">
       {% if post['image'] %}
@@ -49,10 +50,10 @@
       const body = button.parentElement.nextElementSibling;
       if (body.style.display === "none") {
         body.style.display = "block";
-        button.textContent = "Collapse";
+        button.textContent = "{{ 'Collapse' if locale == 'en_GB' else 'Plegar' }}";
       } else {
         body.style.display = "none";
-        button.textContent = "Expand";
+        button.textContent = "{{ 'Expand' if locale == 'en_GB' else 'Desplegar' }}";
       }
     }
   </script>


### PR DESCRIPTION
### Description of the Change
This pull request introduces basic translation support for the blog application by utilizing a "locale" query parameter. The changes allow the application to render text in different languages based on the locale specified in the query parameter, defaulting to 'en_GB' if none is provided.

### Code Changes
- **Login Page**: Updated to display 'Log In' or 'Iniciar sesión' based on the locale.
- **Register Page**: Updated to display 'Register' or 'Registrarse' based on the locale.
- **Base Template**: Added locale-based translation for 'Log Out'.
- **Blog Index Page**: Added locale-based translations for 'Today in history', 'New', 'Edit', 'Expand', and 'Collapse'.

### Issue Link
This pull request addresses the issue described in [Confluence page](https://sagittal.atlassian.net/wiki/spaces/FD/pages/99778587/Translations).

### Contribution Checklist
- [ ] Add tests to demonstrate the correct behavior of the change.
- [ ] Update relevant documentation in the docs folder and in code.
- [ ] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.