### PR TITLE
FLAS-83: Update PR Template for Nov 5th Demo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,3 +23,7 @@ Ensure each step in CONTRIBUTING.rst is complete, especially the following:
 - Add an entry in CHANGES.rst summarizing the change and linking to the issue.
 - Add `.. versionchanged::` entries in any relevant code docs.
 -->
+
+<!--
+Note: All pull requests for the Nov 5th Demo should target the oct-9th-demo branch.
+-->


### PR DESCRIPTION
### Description
This pull request updates the pull request template to include a note specifying that all pull requests for the Nov 5th Demo should target the oct-9th-demo branch. This change ensures that contributors are aware of the correct target branch for their pull requests related to the Nov 5th Demo.

### Related Issue
fixes #83

### Checklist
- [x] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.

### Notes
- Note: All pull requests for the Nov 5th Demo should target the oct-9th-demo branch.